### PR TITLE
GUI: Support for default values in PacketParser

### DIFF
--- a/parser_json/json_example.json
+++ b/parser_json/json_example.json
@@ -1,10 +1,13 @@
 {
-  "description": "This JSON file describes the format for defining packet fields. Each field type has specific rules, especially for 'bit_field' types which can contain nested fields.",
+  "description": "This JSON file describes the format for defining packet fields.",
   "endianness": "Indicates the byte order of the data. Use either 'little' or 'big'.",
   "rules": {
     "endianness": {
       "description": "Specifies the byte order of the data.",
-      "allowed_values": ["little", "big"]
+      "allowed_values": [
+        "little",
+        "big"
+      ]
     },
     "fields": {
       "description": "An array of field definitions. Each field has the following properties:",
@@ -31,8 +34,12 @@
           "description": "The size of the field in bits. Must be a multiple of 8, or 16, 32, 64, etc.",
           "example": 32
         },
+        "default_value": {
+          "description": "Specifies the default value of the field. This field is optional and may be omitted entirely if not needed.",
+          "example": 100
+        },
         "fields": {
-          "description": "An array of sub-fields for composite bit fields. This property is only applicable for fields of type 'bit_field'. For all other field types, the 'fields' property should be omitted.",
+          "description": "An array of sub-fields for composite bit fields.",
           "properties": {
             "name": {
               "description": "The name of the sub-field.",
@@ -55,18 +62,24 @@
             "size": {
               "description": "The size of the sub-field in bits.",
               "example": 32
+            },
+            "default_value": {
+              "description": "Specifies the default value for the sub-field. This field is optional and may be omitted.",
+              "example": 1
             }
           },
           "example": [
             {
               "name": "FloatField1",
               "type": "float_fixed",
-              "size": 32
+              "size": 32,
+              "default_value": 100.0
             },
             {
               "name": "DoubleField1",
               "type": "double",
-              "size": 64
+              "size": 64,
+              "default_value": 50.5
             }
           ]
         }
@@ -75,12 +88,14 @@
         {
           "name": "CharArrayField",
           "type": "char_array",
-          "size": 64
+          "size": 64,
+          "default_value": "DefaultString"
         },
         {
           "name": "FloatField",
           "type": "float_fixed",
-          "size": 32
+          "size": 32,
+          "default_value": 100.0
         },
         {
           "name": "DoubleField",
@@ -90,22 +105,26 @@
         {
           "name": "SignedIntField",
           "type": "signed_int",
-          "size": 32
+          "size": 32,
+          "default_value": -10
         },
         {
           "name": "UnsignedIntField",
           "type": "unsigned_int",
-          "size": 32
+          "size": 32,
+          "default_value": 10
         },
         {
           "name": "FloatMantissaField",
           "type": "float_mantissa",
-          "size": 32
+          "size": 32,
+          "default_value": 1.23
         },
         {
           "name": "BoolField",
           "type": "boolean",
-          "size": 8
+          "size": 8,
+          "default_value": true
         },
         {
           "name": "BitFieldExample1",
@@ -120,12 +139,19 @@
             {
               "name": "UnsignedIntField1",
               "type": "unsigned_int",
-              "size": 32
+              "size": 32,
+              "default_value": 10
             }
           ]
+        },
+        {
+          "name": "NoDefaultField",
+          "type": "signed_int",
+          "size": 32
         }
       ]
     }
   },
-  "note": "The 'fields' property is exclusively used with the 'bit_field' type to define nested sub-fields. For all other field types ('char_array', 'float_fixed', 'float_mantissa', 'double', 'signed_int', 'unsigned_int', 'boolean'), the 'fields' property must be omitted. Ensure that 'size' values correspond to the correct bit-widths for the specified types. Additionally, it is recommended to avoid using 'float' and 'double' types within a 'bit_field', as these types are not properly decoded within bit fields and should be parsed separately."
+  "note": "The 'fields' property is exclusively used with the 'bit_field' type to define ",
+  "note2": "Ensure that 'size' values correspond to the correct bit-widths for the types."
 }

--- a/parser_json/src/packet_parser.h
+++ b/parser_json/src/packet_parser.h
@@ -28,6 +28,7 @@ enum class FieldType {
 struct Field {
     std::string name;
     std::string type;
+    FieldValue defaultValue;
     size_t size;
     size_t offset;
 };
@@ -50,6 +51,7 @@ public:
     void printFieldValues(const std::map<std::string, FieldValue> &fieldValues);
     void setBuffer(const void *buffer);
     std::vector<Field> getBitFieldFields(const std::string &bitFieldName);
+    FieldValue getDefaultValueByType(const std::string &type);
     ~PacketParser();
 
 protected:


### PR DESCRIPTION
### PR Description

**Purpose:**
This Pull Request adds support for default values in the `PacketParser` class of the system. The goal is to enhance the data management capabilities of the `PacketParser` by allowing default values to be defined for different field types.

**Key Changes:**
1. **Addition of Field Types:**
   - New field types have been added to the function handler map, including `signed_int` and `boolean`.
   - Fields with default values can now be stored appropriately in the `PacketParser` data structure.

2. **Interface Improvements:**
   - When `PacketParser` loads JSON with fields, it now recognizes fields with default values and stores them correctly in the `defaultValues` map.

3. **Testing Enhancements:**
   - Tests have been added to ensure that default values are returned correctly for each field type, and in the case of an unknown field, a warning message is provided.

**Benefits:**
- This improvement increases the flexibility of the `PacketParser` and allows developers to set default values more easily, leading to reduced errors and a smoother operation of the system.